### PR TITLE
(feat:adminService), (refactor:clubService)

### DIFF
--- a/src/main/java/com/walkbuddies/backend/admin/controller/AdminClubController.java
+++ b/src/main/java/com/walkbuddies/backend/admin/controller/AdminClubController.java
@@ -1,0 +1,35 @@
+package com.walkbuddies.backend.admin.controller;
+
+import com.walkbuddies.backend.admin.service.AdminClubService;
+import com.walkbuddies.backend.club.dto.ClubDto;
+import com.walkbuddies.backend.common.response.SingleResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminClubController {
+
+    private final AdminClubService adminClubService;
+
+    @PostMapping("/admin/club/status")
+    public ResponseEntity<SingleResponse> setClubStatus(@RequestParam(name = "clubId") Long clubId,
+                                                        @RequestParam(name = "suspended") boolean suspended) {
+
+        SingleResponse singleResponse = new SingleResponse(HttpStatus.OK.value(), "clubId: " + clubId + "에 해당하는 소모임의 상태를 변경했습니다.",
+                adminClubService.setClubStatus(clubId, suspended));
+        return ResponseEntity.ok(singleResponse);
+    }
+
+    @PostMapping("/admin/club/delete")
+    public ResponseEntity<SingleResponse> deleteClub(@RequestParam(name = "clubId") Long clubId) {
+
+        SingleResponse singleResponse = new SingleResponse(HttpStatus.OK.value(), "clubId: " + clubId + "에 해당하는 소모임을 삭제했습니다.",
+                adminClubService.deleteClub(clubId));
+        return ResponseEntity.ok(singleResponse);
+    }
+}

--- a/src/main/java/com/walkbuddies/backend/admin/controller/AdminMemberController.java
+++ b/src/main/java/com/walkbuddies/backend/admin/controller/AdminMemberController.java
@@ -1,0 +1,51 @@
+package com.walkbuddies.backend.admin.controller;
+
+import com.walkbuddies.backend.admin.service.AdminMemberService;
+import com.walkbuddies.backend.common.response.ListResponse;
+import com.walkbuddies.backend.common.response.SingleResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminMemberController {
+
+    private final AdminMemberService adminMemberService;
+
+    @GetMapping("/admin/member/list")
+    public ResponseEntity<ListResponse> getMemberList() {
+
+        ListResponse listResponse = new ListResponse(HttpStatus.OK.value(), "회원 리스트를 불러왔습니다.",
+                adminMemberService.getMemberList());
+        return ResponseEntity.ok(listResponse);
+    }
+
+    @GetMapping("/admin/member/name")
+    public ResponseEntity<ListResponse> getMemberName(@RequestParam(name = "name") String name) {
+
+        ListResponse listResponse = new ListResponse(HttpStatus.OK.value(), "이름 " + name + "을 가진 회원 목록을 불러왔습니다.",
+                adminMemberService.getMemberName(name));
+        return ResponseEntity.ok(listResponse);
+    }
+
+    @GetMapping("/admin/member/detail")
+    public ResponseEntity<SingleResponse> getMemberDetail(@RequestParam(name = "memberId") Long memberId) {
+
+        SingleResponse singleResponse = new SingleResponse(HttpStatus.OK.value(), "memberId: " + memberId + "에 해당하는 멤버의 정보를 불러왔습니다.",
+                adminMemberService.getMemberDetail(memberId));
+        return ResponseEntity.ok(singleResponse);
+    }
+
+    @GetMapping("/admin/member/nickName")
+    public ResponseEntity<SingleResponse> getMemberNickName(@RequestParam(name = "nickName") String nickName) {
+
+        SingleResponse singleResponse = new SingleResponse(HttpStatus.OK.value(), "닉네임 " + nickName + "을 가진 회원 정보를 불러왔습니다.",
+                adminMemberService.getMemberNickName(nickName));
+        return ResponseEntity.ok(singleResponse);
+    }
+}
+

--- a/src/main/java/com/walkbuddies/backend/admin/dto/MemberDetailDto.java
+++ b/src/main/java/com/walkbuddies/backend/admin/dto/MemberDetailDto.java
@@ -1,0 +1,37 @@
+package com.walkbuddies.backend.admin.dto;
+
+import com.walkbuddies.backend.club.domain.TownEntity;
+import lombok.*;
+
+import java.util.Date;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberDetailDto {
+
+    private Long memberId;
+    private Long townId;
+    private String email;
+    private String password;
+    private String name;
+    private String nickName;
+    private Integer gender;
+    private Date createAt;
+    private Date updateAt;
+    private Integer loginType;
+    private String imageUrl;
+    private String introduction;
+    private String salt;
+    private Date passwordUpdate;
+    private Integer socialCode;
+    private String oauthExternalId;
+    private String accessToken;
+    private boolean verify;
+    private String verificationCode;
+    private Date verifyExpiredAt;
+    private Date townVerificationDate;
+
+}

--- a/src/main/java/com/walkbuddies/backend/admin/service/AdminClubService.java
+++ b/src/main/java/com/walkbuddies/backend/admin/service/AdminClubService.java
@@ -1,0 +1,23 @@
+package com.walkbuddies.backend.admin.service;
+
+import com.walkbuddies.backend.club.dto.ClubDto;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface AdminClubService {
+
+    /**
+     * 소모임 상태 설정 메서드
+     * @param clubId
+     * @param suspended
+     * @return
+     */
+    ClubDto setClubStatus(Long clubId, boolean suspended);
+
+    /**
+     * 소모임을 삭제하는 메서드
+     * @param clubId
+     * @return
+     */
+    ClubDto deleteClub(Long clubId);
+}

--- a/src/main/java/com/walkbuddies/backend/admin/service/AdminMemberService.java
+++ b/src/main/java/com/walkbuddies/backend/admin/service/AdminMemberService.java
@@ -1,0 +1,38 @@
+package com.walkbuddies.backend.admin.service;
+
+import com.walkbuddies.backend.admin.dto.MemberDetailDto;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public interface AdminMemberService {
+
+    /**
+     * 모든 회원 정보를 리스트로 불러오는 메서드
+     * @return
+     */
+    List<MemberDetailDto> getMemberList();
+
+    /**
+     * 회원 식별자를 통해 그 회원의 정보를 불러오는 메서드
+     * @param memberId
+     * @return
+     */
+    MemberDetailDto getMemberDetail(Long memberId);
+
+    /**
+     * 파라미터 이름에 해당하는 모든 회원의 정보를 리스트로 불러오는 메서드
+     * @param name
+     * @return
+     */
+    List<MemberDetailDto> getMemberName(String name);
+
+    /**
+     * 닉네임에 해당하는 회원의 정보를 불러오는 메서드
+     * @param nickName
+     * @return
+     */
+    MemberDetailDto getMemberNickName(String nickName);
+
+}

--- a/src/main/java/com/walkbuddies/backend/admin/service/impl/AdminClubServiceImpl.java
+++ b/src/main/java/com/walkbuddies/backend/admin/service/impl/AdminClubServiceImpl.java
@@ -1,0 +1,84 @@
+package com.walkbuddies.backend.admin.service.impl;
+
+import com.walkbuddies.backend.admin.service.AdminClubService;
+import com.walkbuddies.backend.club.domain.ClubEntity;
+import com.walkbuddies.backend.club.domain.TownEntity;
+import com.walkbuddies.backend.club.dto.ClubDto;
+import com.walkbuddies.backend.club.repository.ClubRepository;
+import com.walkbuddies.backend.club.repository.TownRepository;
+import com.walkbuddies.backend.exception.impl.NotFoundClubException;
+import com.walkbuddies.backend.exception.impl.NotFoundMemberException;
+import com.walkbuddies.backend.member.domain.MemberEntity;
+import com.walkbuddies.backend.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class AdminClubServiceImpl implements AdminClubService {
+
+    private final ClubRepository clubRepository;
+    private final MemberRepository memberRepository;
+    private final TownRepository townRepository;
+
+    /**
+     * 소모임 상태 설정 메서드
+     * @param clubId
+     * @param suspended
+     * @return
+     */
+    @Transactional
+    @Override
+    public ClubDto setClubStatus(Long clubId, boolean suspended) {
+
+        ClubEntity clubEntity = getClubEntity(clubId);
+        ClubDto clubDto = ClubEntity.entityToDto(clubEntity);
+
+        MemberEntity memberEntity = getMemberEntity(clubDto.getOwnerId());
+        TownEntity townEntity = townRepository.findByTownId(clubDto.getTownId());
+
+        ClubEntity updatedClubEntity = ClubEntity.builder()
+                .clubId(clubDto.getClubId())
+                .clubName(clubDto.getClubName())
+                .townId(townEntity)
+                .ownerId(memberEntity)
+                .members(clubEntity.getMembers())
+                .membersLimit(clubDto.getMembersLimit())
+                .accessLimit(clubDto.getAccessLimit())
+                .needGrant(clubDto.getNeedGrant())
+                .regDate(clubEntity.getRegDate())
+                .modDate(LocalDate.now())
+                .build();
+        clubRepository.save(updatedClubEntity);
+
+        return ClubEntity.entityToDto(updatedClubEntity);
+    }
+
+    /**
+     * 소모임을 삭제하는 메서드
+     * @param clubId
+     * @return
+     */
+    @Override
+    public ClubDto deleteClub(Long clubId) {
+
+        ClubEntity clubEntity = getClubEntity(clubId);
+
+        clubRepository.delete(clubEntity);
+
+        return ClubEntity.entityToDto(clubEntity);
+    }
+
+    private ClubEntity getClubEntity(Long clubId) {
+        return clubRepository.findByClubId(clubId)
+                .orElseThrow(() -> new NotFoundClubException());
+    }
+
+    private MemberEntity getMemberEntity(Long memberId) {
+        return memberRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new NotFoundMemberException());
+    }
+}

--- a/src/main/java/com/walkbuddies/backend/admin/service/impl/AdminMemberServiceImpl.java
+++ b/src/main/java/com/walkbuddies/backend/admin/service/impl/AdminMemberServiceImpl.java
@@ -1,0 +1,96 @@
+package com.walkbuddies.backend.admin.service.impl;
+
+import com.walkbuddies.backend.admin.dto.MemberDetailDto;
+import com.walkbuddies.backend.admin.service.AdminMemberService;
+import com.walkbuddies.backend.exception.impl.NotFoundNameException;
+import com.walkbuddies.backend.exception.impl.NotFoundNickNameException;
+import com.walkbuddies.backend.member.domain.MemberEntity;
+import com.walkbuddies.backend.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminMemberServiceImpl implements AdminMemberService {
+
+    private final MemberRepository memberRepository;
+
+    /**
+     * 모든 회원 정보를 리스트로 불러오는 메서드
+     * @return
+     */
+    @Override
+    public List<MemberDetailDto> getMemberList() {
+
+        List<MemberEntity> memberList = memberRepository.findAll();
+        List<MemberDetailDto> memberDetailDtos = new ArrayList<>();
+
+        for (MemberEntity memberEntity : memberList) {
+            MemberDetailDto memberDetailDto = MemberEntity.entityToDetail(memberEntity);
+            memberDetailDtos.add(memberDetailDto);
+        }
+
+        return memberDetailDtos;
+    }
+
+    /**
+     * 회원 식별자를 통해 그 회원의 정보를 불러오는 메서드
+     * @param memberId
+     * @return
+     */
+    @Override
+    public MemberDetailDto getMemberDetail(Long memberId) {
+
+        Optional<MemberEntity> memberEntity = memberRepository.findByMemberId(memberId);
+        MemberEntity member = memberEntity.get();
+
+        return MemberEntity.entityToDetail(member);
+    }
+
+    /**
+     * 파라미터 이름에 해당하는 모든 회원의 정보를 리스트로 불러오는 메서드
+     * @param name
+     * @return
+     */
+    @Override
+    public List<MemberDetailDto> getMemberName(String name) {
+
+        Optional<List<MemberEntity>> memberList = memberRepository.findByName(name);
+        if (memberList.get().isEmpty()) {
+            throw new NotFoundNameException();
+        }
+
+        List<MemberDetailDto> memberDetailDtos = new ArrayList<>();
+
+        for (MemberEntity memberEntity : memberList.get()) {
+            MemberDetailDto memberDetailDto = MemberEntity.entityToDetail(memberEntity);
+            memberDetailDtos.add(memberDetailDto);
+        }
+
+        return memberDetailDtos;
+    }
+
+    /**
+     * 닉네임에 해당하는 회원의 정보를 불러오는 메서드
+     * @param nickName
+     * @return
+     */
+    @Override
+    public MemberDetailDto getMemberNickName(String nickName) {
+
+        Optional<MemberEntity> memberEntity = memberRepository.findByNickname(nickName);
+        if (memberEntity.isEmpty()) {
+            throw new NotFoundNickNameException();
+        }
+
+        MemberEntity member = memberEntity.get();
+
+
+        return MemberEntity.entityToDetail(member);
+    }
+
+}

--- a/src/main/java/com/walkbuddies/backend/club/controller/ClubController.java
+++ b/src/main/java/com/walkbuddies/backend/club/controller/ClubController.java
@@ -2,6 +2,8 @@ package com.walkbuddies.backend.club.controller;
 
 import com.walkbuddies.backend.club.dto.ClubDto;
 import com.walkbuddies.backend.club.dto.ClubJoinInform;
+import com.walkbuddies.backend.club.dto.ClubParameter;
+import com.walkbuddies.backend.club.dto.ClubUpdateParameter;
 import com.walkbuddies.backend.club.service.ClubService;
 import com.walkbuddies.backend.common.response.ListResponse;
 import com.walkbuddies.backend.common.response.SingleResponse;
@@ -29,22 +31,20 @@ public class ClubController {
     }
 
     @PostMapping("/club/delete")
-    public ResponseEntity<SingleResponse> deleteClub(@RequestParam(name = "ownerId") Long ownerId,
-                                                   @RequestParam(name = "clubId") Long clubId) {
+    public ResponseEntity<SingleResponse> deleteClub(@RequestBody ClubParameter clubParameter) {
 
         SingleResponse singleResponse = new SingleResponse(HttpStatus.OK.value(), "소모임 폐쇄를 완료했습니다.",
-                clubService.deleteClub(ownerId, clubId));
+                clubService.deleteClub(clubParameter));
 
         return ResponseEntity.ok(singleResponse);
     }
 
     @GetMapping("/club/search")
-    public ResponseEntity<ListResponse> searchClub(@RequestParam(name = "townId") Long townId,
-                                                   @RequestParam(name = "clubName") String clubName) {
+    public ResponseEntity<ListResponse> searchClub(@RequestBody ClubParameter clubParameter) {
 
-        List<String> foundClubs = clubService.searchClub(townId, clubName);
+        List<String> foundClubs = clubService.searchClub(clubParameter);
         ListResponse listResponse = new ListResponse(HttpStatus.OK.value(),
-                clubName + "이(가) 포함된 소모임이 검색되었습니다.", foundClubs);
+                clubParameter.getClubName() + "이(가) 포함된 소모임이 검색되었습니다.", foundClubs);
 
         return ResponseEntity.ok(listResponse);
     }
@@ -59,46 +59,43 @@ public class ClubController {
     }
 
     @GetMapping("/club/join/waiting")
-    public ResponseEntity<ListResponse> getClubWaitingData(@RequestParam(name = "clubId") Long clubId) {
+    public ResponseEntity<ListResponse> getClubWaitingData(@RequestBody ClubParameter clubParameter) {
 
-        List<String> foundMembers = clubService.getClubWaitingData(clubId);
+        List<String> foundMembers = clubService.getClubWaitingData(clubParameter);
         ListResponse listResponse = new ListResponse(HttpStatus.OK.value(),
-                "소모임 ID: " + clubId + "에 가입 신청한 회원 목록입니다.", foundMembers);
+                "소모임 ID: " + clubParameter.getClubId() + "에 가입 신청한 회원 목록입니다.", foundMembers);
 
         return ResponseEntity.ok(listResponse);
     }
 
     @PostMapping("/club/join/response")
-    public ResponseEntity<SingleResponse> joinClubResponse(@RequestParam(name = "allowJoin") boolean allowJoin,
-                                                         @RequestBody ClubJoinInform clubJoinInform) {
+    public ResponseEntity<SingleResponse> joinClubResponse(@RequestBody ClubJoinInform clubJoinInform) {
 
         SingleResponse singleResponse = new SingleResponse(HttpStatus.OK.value(), "소모임 가입 신청에 대한 응답입니다.",
-                clubService.joinClubResponse(allowJoin, clubJoinInform));
+                clubService.joinClubResponse(clubJoinInform));
         return ResponseEntity.ok(singleResponse);
     }
 
     @PostMapping("club/leave")
-    public ResponseEntity<SingleResponse> leaveClub(@RequestParam(name = "clubId") Long clubId,
-                                                  @RequestParam(name = "memberId") Long memberId) {
+    public ResponseEntity<SingleResponse> leaveClub(@RequestBody ClubParameter clubParameter) {
 
         SingleResponse singleResponse = new SingleResponse(HttpStatus.OK.value(), "소모임 탈퇴가 완료 되었습니다.",
-                clubService.leaveClub(clubId, memberId));
+                clubService.leaveClub(clubParameter));
         return ResponseEntity.ok(singleResponse);
     }
 
     @PostMapping("/club/update")
-    public ResponseEntity<SingleResponse> updateClubData(@RequestParam(name = "ownerId") Long ownerId,
-                                                       @RequestBody  ClubDto clubDto) {
+    public ResponseEntity<SingleResponse> updateClubData(@RequestBody ClubUpdateParameter clubUpdateParameter) {
 
-        SingleResponse singleResponse = new SingleResponse(HttpStatus.OK.value(), "소모임 정보를 수정했습니다.", clubService.updateClubData(ownerId, clubDto));
+        SingleResponse singleResponse = new SingleResponse(HttpStatus.OK.value(), "소모임 정보를 수정했습니다.", clubService.updateClubData(clubUpdateParameter));
         return ResponseEntity.ok(singleResponse);
     }
 
     @GetMapping("/club/myclub")
-    public ResponseEntity<ListResponse> getMyClub(@RequestParam(name = "memberId") Long memberId) {
+    public ResponseEntity<ListResponse> getMyClub(@RequestBody ClubParameter clubParameter) {
 
         ListResponse listResponse = new ListResponse(HttpStatus.OK.value(),
-               "가입한 소모임 목록을 불러왔습니다.", clubService.getMyClub(memberId));
+               "가입한 소모임 목록을 불러왔습니다.", clubService.getMyClub(clubParameter));
        return ResponseEntity.ok(listResponse);
     }
 }

--- a/src/main/java/com/walkbuddies/backend/club/domain/ClubEntity.java
+++ b/src/main/java/com/walkbuddies/backend/club/domain/ClubEntity.java
@@ -36,6 +36,7 @@ public class ClubEntity {
     private Integer membersLimit;
     private Integer accessLimit;
     private Integer needGrant;
+    private boolean isSuspended;
     private LocalDate regDate;
     private LocalDate modDate;
 
@@ -50,6 +51,7 @@ public class ClubEntity {
                 .membersLimit(clubEntity.getMembersLimit())
                 .accessLimit(clubEntity.getAccessLimit())
                 .needGrant(clubEntity.getNeedGrant())
+                .isSuspended(clubEntity.isSuspended())
                 .regDate(clubEntity.getRegDate())
                 .modDate(clubEntity.getModDate())
                 .build();

--- a/src/main/java/com/walkbuddies/backend/club/domain/ClubWaitingEntity.java
+++ b/src/main/java/com/walkbuddies/backend/club/domain/ClubWaitingEntity.java
@@ -27,5 +27,9 @@ public class ClubWaitingEntity {
     @JoinColumn(name = "memberId")
     private MemberEntity memberId;
 
+    @ManyToOne
+    @JoinColumn(name = "nickname")
+    private MemberEntity nickName;
+
     private String message;
 }

--- a/src/main/java/com/walkbuddies/backend/club/dto/ClubParameter.java
+++ b/src/main/java/com/walkbuddies/backend/club/dto/ClubParameter.java
@@ -7,11 +7,13 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ClubJoinInform {
+public class ClubParameter {
 
-    private Long memberId;
     private Long clubId;
+    private Long memberId;
+    private Long ownerId;
     private Long townId;
-    private String message;
-    private Boolean allowJoin;
+    private String clubName;
+
+
 }

--- a/src/main/java/com/walkbuddies/backend/club/dto/ClubUpdateParameter.java
+++ b/src/main/java/com/walkbuddies/backend/club/dto/ClubUpdateParameter.java
@@ -1,18 +1,15 @@
 package com.walkbuddies.backend.club.dto;
 
-import com.walkbuddies.backend.club.domain.ClubEntity;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ClubDto {
-
+public class ClubUpdateParameter {
     private Long clubId;
     private String clubName;
     private Long townId;
@@ -24,4 +21,6 @@ public class ClubDto {
     private Boolean isSuspended;
     private LocalDate regDate;
     private LocalDate modDate;
+
+    private Long memberId;
 }

--- a/src/main/java/com/walkbuddies/backend/club/service/ClubService.java
+++ b/src/main/java/com/walkbuddies/backend/club/service/ClubService.java
@@ -2,7 +2,10 @@ package com.walkbuddies.backend.club.service;
 
 import com.walkbuddies.backend.club.dto.ClubDto;
 import com.walkbuddies.backend.club.dto.ClubJoinInform;
+import com.walkbuddies.backend.club.dto.ClubParameter;
+import com.walkbuddies.backend.club.dto.ClubUpdateParameter;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 
@@ -18,20 +21,20 @@ public interface ClubService {
 
     /**
      * 소모임 폐쇄 메서드
-     * @param ownerId
-     * @param clubId
+     *
+     * @param clubParameter
      * @return
      */
-    ClubDto deleteClub(Long ownerId, Long clubId);
+    ClubDto deleteClub(ClubParameter clubParameter);
 
     /**
      * 소모임 검색 기능 메서드.
      * 검색어가 포함되고 검색이 되도록 한 소모임에 한에서 모두 검색이 됨.
      *
-     * @param clubName
+     * @param clubParameter
      * @return
      */
-    List<String> searchClub(Long townId, String clubName);
+    List<String> searchClub(ClubParameter clubParameter);
 
     /**
      * 소모임 가입 요청 기능 메서드
@@ -46,41 +49,40 @@ public interface ClubService {
      * 소모임 Id를 기반으로 소모임의 가입 신청자를 볼 수 있는 메서드.
      * 신청자의 memberId와 가입시 작성했던 message를 함께 볼 수 있음.
      *
-     * @param clubId
+     * @param clubParameter
      * @return
      */
-    List<String> getClubWaitingData(Long clubId);
+    List<String> getClubWaitingData(ClubParameter clubParameter);
 
     /**
      * 소모임 신청자 가입 승인, 거절 메서드.
      * 승인에 대한 Boolean 타입과 정보를 받아서 승인할지 거절할지 정함.
      *
-     * @param allowJoin
      * @param clubJoinInform
      * @return
      */
-    String joinClubResponse(Boolean allowJoin, ClubJoinInform clubJoinInform);
+    String joinClubResponse(ClubJoinInform clubJoinInform);
 
     /**
      * 소모임 탈퇴 메서드.
-     * @param clubId
-     * @param memberId
+     *
+     * @param clubParameter
      * @return
      */
-    String leaveClub(Long clubId, Long memberId);
+    String leaveClub(ClubParameter clubParameter);
 
     /**
      * 소모임 정보를 수정하는 메서드
-     * @param ownerId
-     * @param clubDto
+     *
+     * @param clubUpdateParameter
      * @return
      */
-    ClubDto updateClubData(Long ownerId, ClubDto clubDto);
+    ClubDto updateClubData(ClubUpdateParameter clubUpdateParameter);
 
     /**
      * 내 소모임 목록 보기 메서드
-     * @param memberId
+     * @param clubParameter
      * @return
      */
-    List<ClubDto> getMyClub(Long memberId);
+    List<ClubDto> getMyClub(ClubParameter clubParameter);
 }

--- a/src/main/java/com/walkbuddies/backend/exception/impl/ClubSuspendedException.java
+++ b/src/main/java/com/walkbuddies/backend/exception/impl/ClubSuspendedException.java
@@ -1,0 +1,16 @@
+package com.walkbuddies.backend.exception.impl;
+
+import com.walkbuddies.backend.exception.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class ClubSuspendedException extends AbstractException {
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.BAD_REQUEST.value();
+    }
+
+    @Override
+    public String getMessage() {
+        return "임시조치 된 소모임 입니다.";
+    }
+}

--- a/src/main/java/com/walkbuddies/backend/exception/impl/NotClubAdminException.java
+++ b/src/main/java/com/walkbuddies/backend/exception/impl/NotClubAdminException.java
@@ -3,7 +3,7 @@ package com.walkbuddies.backend.exception.impl;
 import com.walkbuddies.backend.exception.AbstractException;
 import org.springframework.http.HttpStatus;
 
-public class NotAdminException extends AbstractException {
+public class NotClubAdminException extends AbstractException {
     @Override
     public int getStatusCode() {
         return HttpStatus.BAD_REQUEST.value();

--- a/src/main/java/com/walkbuddies/backend/exception/impl/NotFoundNameException.java
+++ b/src/main/java/com/walkbuddies/backend/exception/impl/NotFoundNameException.java
@@ -1,0 +1,16 @@
+package com.walkbuddies.backend.exception.impl;
+
+import com.walkbuddies.backend.exception.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundNameException extends AbstractException {
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.NOT_FOUND.value();
+    }
+
+    @Override
+    public String getMessage() {
+        return "해당하는 이름을 가진 회원이 없습니다.";
+    }
+}

--- a/src/main/java/com/walkbuddies/backend/exception/impl/NotFoundNickNameException.java
+++ b/src/main/java/com/walkbuddies/backend/exception/impl/NotFoundNickNameException.java
@@ -1,0 +1,16 @@
+package com.walkbuddies.backend.exception.impl;
+
+import com.walkbuddies.backend.exception.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundNickNameException extends AbstractException {
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.NOT_FOUND.value();
+    }
+
+    @Override
+    public String getMessage() {
+        return "해당하는 닉네임을 가진 회원이 없습니다.";
+    }
+}

--- a/src/main/java/com/walkbuddies/backend/member/domain/MemberEntity.java
+++ b/src/main/java/com/walkbuddies/backend/member/domain/MemberEntity.java
@@ -1,5 +1,6 @@
 package com.walkbuddies.backend.member.domain;
 
+import com.walkbuddies.backend.admin.dto.MemberDetailDto;
 import com.walkbuddies.backend.club.domain.TownEntity;
 import com.walkbuddies.backend.common.SHA256;
 import com.walkbuddies.backend.member.dto.SignUpDto;
@@ -73,5 +74,32 @@ public class MemberEntity {
         this.updateAt = new Date();
         this.salt = salt;
         this.passwordUpdate = new Date();
+    }
+
+    public static MemberDetailDto entityToDetail(MemberEntity memberEntity) {
+
+        return MemberDetailDto.builder()
+                .memberId(memberEntity.getMemberId())
+                .townId(memberEntity.getTownId().getTownId())
+                .email(memberEntity.getEmail())
+                .password(memberEntity.getPassword())
+                .name(memberEntity.getName())
+                .nickName(memberEntity.getNickname())
+                .gender(memberEntity.getGender())
+                .createAt(memberEntity.getCreateAt())
+                .updateAt(memberEntity.getUpdateAt())
+                .loginType(memberEntity.getLoginType())
+                .imageUrl(memberEntity.getImageUrl())
+                .introduction(memberEntity.getIntroduction())
+                .salt(memberEntity.getSalt())
+                .passwordUpdate(memberEntity.getPasswordUpdate())
+                .socialCode(memberEntity.getSocialCode())
+                .oauthExternalId(memberEntity.getOauthExternalId())
+                .accessToken(memberEntity.getAccessToken())
+                .verify(memberEntity.isVerify())
+                .verificationCode(memberEntity.getVerificationCode())
+                .verifyExpiredAt(memberEntity.getVerifyExpiredAt())
+                .townVerificationDate(memberEntity.getTownVerificationDate())
+                .build();
     }
 }

--- a/src/main/java/com/walkbuddies/backend/member/repository/MemberRepository.java
+++ b/src/main/java/com/walkbuddies/backend/member/repository/MemberRepository.java
@@ -4,9 +4,14 @@ import com.walkbuddies.backend.member.domain.MemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
     Optional<MemberEntity> findByMemberId(Long memberId);
+
+    Optional<List<MemberEntity>> findByName(String name);
+
+    Optional<MemberEntity> findByNickname(String nickName);
 }


### PR DESCRIPTION
adminService의 회원 부분과 소모임 부분을 만들었습니다.
회원 부분의 회원 상태 설정은 회원 부분의 memberStatus에 관련된 부분이 작성되면 마저 만들겠습니다. adminService의 Exception 처리는 memberStatus에 관련된 부분이 작성 된 뒤 만들겠습니다. clubService에서 사용하는 파라미터를 통일했습니다.
기존에는 RequestParam과 RequestBody를 혼합해서 사용했는데
이번에 clubParameter와 clubUpdateParameter를 만들어서 파라미터를 RequestBody로 통일했습니다.